### PR TITLE
Reduce usage of the message 'artifact' dict

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
                        queue: 'osci-pipelines-queue-1'
                    ],
                    checks: [
-                       [field: '$.artifact.release', expectedValue: '^f35$']
+                       [field: '$.update.release.dist_tag', expectedValue: '^f35$']
                    ]
                )
            ]


### PR DESCRIPTION
To help with https://pagure.io/fedora-ci/general/issue/436 , this reduces use of the 'artifact' dict from the Bodhi 'update ready for testing' message to only use the 'task_id' and 'id' (which is the build id) values from the 'build' dicts. This will let us simplify the message format in Bodhi.